### PR TITLE
fix: itemForm / submitButton style

### DIFF
--- a/front/components/recycle/ItemForm.tsx
+++ b/front/components/recycle/ItemForm.tsx
@@ -283,5 +283,6 @@ const Float = styled.div`
 `;
 
 const SubmitButton = styled.div`
-  width: 200px;
+  width: 100%;
+  max-width: 200px;
 `;


### PR DESCRIPTION
- 이슈사항 : 모바일 환경에서 아이템 수정 시 UI 깨짐 현상
- 원인 : 하단 button 의 width 가 200px 로 고정되어있었음.
- 해결 : width: 100%, max-width: 200px 로 해결