### PR TITLE
Feat/chart: Price Chart 데스크탑 뷰 server data 와 연동

### DIFF
--- a/front/components/chart/SelectCategories.tsx
+++ b/front/components/chart/SelectCategories.tsx
@@ -1,18 +1,25 @@
-import React, { useState } from 'react';
-import styled, { css } from 'styled-components';
+import React from 'react';
+import styled from 'styled-components';
 import { Tag } from 'antd';
+import { useSelector, useDispatch } from 'react-redux';
 
 import { media } from '../../styles/media';
+import { rootReducerType } from '../../reducers/types';
+import { selectCategoriesAction } from '../../reducers/chart';
+import { Categories } from '../../util/Types/response';
 
 const { CheckableTag } = Tag;
-const tagsData = ['Outer', 'Shirt', 'Pant', 'Top', 'Shoe', 'Muffler'];
+const tagsData: Categories[] = ['Outer', 'Shirt', 'Pant', 'Top', 'Shoe', 'Muffler'];
 
 const SelectCategories = () => {
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const dispatch = useDispatch();
+  const { selectedCategoriesInPrice } = useSelector((state: rootReducerType) => state.chart);
 
-  const handleChange = (tag: string, checked: boolean) => {
-    const nextSelectedTags = checked ? [...selectedTags, tag] : selectedTags.filter(t => t !== tag);
-    setSelectedTags(nextSelectedTags);
+  const handleChange = (tag: Categories, checked: boolean) => {
+    const nextSelectedTags = checked
+      ? [...selectedCategoriesInPrice, tag]
+      : selectedCategoriesInPrice.filter(t => t !== tag);
+    dispatch(selectCategoriesAction(nextSelectedTags));
   };
 
   return (
@@ -26,7 +33,7 @@ const SelectCategories = () => {
           {tagsData.map(tag => (
             <CheckableTag
               key={tag}
-              checked={selectedTags.includes(tag)}
+              checked={selectedCategoriesInPrice.includes(tag)}
               onChange={checked => handleChange(tag, checked)}
             >
               {tag}

--- a/front/components/chart/SelectYearPicker.tsx
+++ b/front/components/chart/SelectYearPicker.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import styled from 'styled-components';
+import { useDispatch } from 'react-redux';
 
 import { DatePicker } from 'antd';
 import { DatePickerProps } from 'antd/es/date-picker';
 import { media } from '../../styles/media';
+import { selectYearAction } from '../../reducers/chart';
 
 const SelectYearPicker = () => {
+  const dispatch = useDispatch();
   const onChange: DatePickerProps['onChange'] = (date, dateString) => {
-    console.log(dateString);
+    dispatch(selectYearAction(Number(dateString)));
   };
 
   return (

--- a/front/components/chart/price/PriceChartDesktop.tsx
+++ b/front/components/chart/price/PriceChartDesktop.tsx
@@ -3,9 +3,9 @@ import { ResponsiveLine } from '@nivo/line';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
 import { SWR } from '../../../util/SWR/API';
-import { convertDataToDesktopChart, lineColors } from '../../../util/Chart/Price/convertData';
+import { convertDataToDesktopChart } from '../../../util/Chart/Price/convertData';
 
-import { dummyPriceData } from '../__mocks__/PriceData';
+import PriceCustomToolTip from './PriceCustomToolTip';
 import { rootReducerType } from '../../../reducers/types';
 
 type PriceChartDesktopProps = {
@@ -20,6 +20,7 @@ const PriceChartDesktop = ({ fallback }: PriceChartDesktopProps) => {
     selectedYearInPrice,
     selectedCategoriesInPrice
   );
+  const length = Data[1] ? Data[1].id.length : 0;
 
   if (fallback) {
     return (
@@ -62,7 +63,9 @@ const PriceChartDesktop = ({ fallback }: PriceChartDesktopProps) => {
             legendPosition: 'middle',
           }}
           enableGridX={false}
-          colors={lineColors}
+          colors={({ color }) => {
+            return color;
+          }}
           lineWidth={1}
           pointSize={4}
           pointColor={{ theme: 'labels.text.fill' }}
@@ -82,8 +85,8 @@ const PriceChartDesktop = ({ fallback }: PriceChartDesktopProps) => {
               justify: false,
               translateX: 0,
               translateY: 0,
-              itemsSpacing: 0,
-              itemDirection: 'left-to-right',
+              itemsSpacing: length,
+              itemDirection: 'bottom-to-top',
               itemWidth: 80,
               itemHeight: 20,
               itemOpacity: 0.75,
@@ -103,6 +106,7 @@ const PriceChartDesktop = ({ fallback }: PriceChartDesktopProps) => {
           ]}
           animate={false}
           motionConfig='wobbly'
+          sliceTooltip={PriceCustomToolTip}
         />
       </PriceChartSection>
     );

--- a/front/components/chart/price/PriceCustomToolTip.tsx
+++ b/front/components/chart/price/PriceCustomToolTip.tsx
@@ -1,0 +1,63 @@
+import styled from 'styled-components';
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { SliceTooltipProps } from '@nivo/line';
+import { getChartPointId } from '../../../reducers/chart';
+import useDelayCall from '../../../hooks/useDelayCall';
+
+export default function PriceCustomToolTip(props: SliceTooltipProps) {
+  const dispatch = useDispatch();
+  const reversePoints = props.slice.points.flat().reverse();
+  let Index = reversePoints[0].index;
+
+  const dispatchIndex = useCallback(() => {
+    dispatch(getChartPointId(Index));
+  }, [Index]);
+
+  useDelayCall(dispatchIndex, Index);
+
+  return (
+    <ToolTipContainer>
+      <ToolTipTitle>월 별 총합(만원단위)</ToolTipTitle>
+      {reversePoints.map(item => {
+        return (
+          <ToolTipItem>
+            <span>{item.serieId}</span>
+            <span>{item.data.yFormatted}</span>
+          </ToolTipItem>
+        );
+      })}
+    </ToolTipContainer>
+  );
+}
+
+const ToolTipContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 1rem;
+  width: 100%;
+  height: auto;
+  padding: 1rem;
+  background-color: ${({ theme }) => theme.colors.white};
+  border: 1px solid ${({ theme }) => theme.colors.lightBlack};
+  border-radius: 0.5rem;
+`;
+
+const ToolTipTitle = styled.h2`
+  font-size: 1rem;
+  font-family: ${({ theme }) => theme.font.Kfont};
+  font-weight: ${({ theme }) => theme.fontWeight.Medium};
+  color: ${({ theme }) => theme.colors.orange};
+`;
+
+const ToolTipItem = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  height: auto;
+`;

--- a/front/components/chart/price/PriceMonthlyItems.tsx
+++ b/front/components/chart/price/PriceMonthlyItems.tsx
@@ -5,9 +5,10 @@ import { useSelector } from 'react-redux';
 
 import { media } from '../../../styles/media';
 import LinkCardLayout from '../../recycle/layout/LinkCardLayout';
-import { SkeletonListItem } from '../../recycle/ListItem';
+import ListItem, { SkeletonListItem } from '../../recycle/ListItem';
 import { SWR } from '../../../util/SWR/API';
 import { ItemsArray } from '../../store/TableData';
+import { SortedTotalData } from '../../../util/Chart/Price/convertData';
 import { rootReducerType } from '../../../reducers/types';
 
 type PriceMonthlyItemsProps = {
@@ -33,21 +34,34 @@ const ListItems = ({ fallback, children }: ListItemsProps) => {
 const PriceMonthlyItems = ({ fallback }: PriceMonthlyItemsProps) => {
   const { selectedMonthIndexInPrice, selectedYearInPrice } = useSelector((state: rootReducerType) => state.chart);
   const { itemsPerYear, error } = SWR.getItemsPerYear(selectedYearInPrice);
+  const { items } = SortedTotalData(itemsPerYear?.items, selectedYearInPrice);
+
+  const ListsPerMonth = items[selectedMonthIndexInPrice];
 
   const moveToStore = useCallback(() => {
     Router.push('/closet/store');
   }, []);
 
+  const moveToDetailsPage = useCallback(
+    (id: number) => () => {
+      Router.push(`/closet/details/${id}`);
+    },
+    []
+  );
+
   return (
     <LinkCardLayout Subject='Monthly Itmes' Address='Store' onMove={moveToStore}>
       <ResultsListContainer>
         <Flex>
-          <h4>월별 저장 의류: {fallback ? '--' : 2} 벌 </h4>
+          <h4>
+            <Strong>{selectedMonthIndexInPrice + 1}</Strong> 월 저장 의류:{' '}
+            <Strong>{fallback ? '--' : ListsPerMonth?.length}</Strong> 벌{' '}
+          </h4>
         </Flex>
         <ListItems fallback={fallback}>
-          {/* {data?.matchedDatas.map((item: ItemsArray) => {
-          return <ListItem key={item.id} item={item} func={moveToDetailPage} />;
-        })} */}
+          {ListsPerMonth?.map((item: ItemsArray) => {
+            return <ListItem key={item.id} item={item} func={moveToDetailsPage} exceptPrice={true} />;
+          })}
         </ListItems>
       </ResultsListContainer>
     </LinkCardLayout>
@@ -66,8 +80,13 @@ const ResultsListContainer = styled.section`
 
   h4 {
     display: block;
-    color: ${({ theme }) => theme.colors.symbol};
+    color: ${({ theme }) => theme.colors.lightBlack};
   }
+`;
+
+const Strong = styled.strong`
+  color: ${({ theme }) => theme.colors.orange};
+  font-family: ${({ theme }) => theme.font.Efont};
 `;
 
 const Flex = styled.div`
@@ -81,17 +100,6 @@ const Flex = styled.div`
   ${media.tablet} {
     flex-direction: row;
     align-items: center;
-  }
-`;
-
-const SummarySearchResults = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 2rem;
-
-  strong {
-    color: ${({ theme }) => theme.colors.symbol};
   }
 `;
 

--- a/front/components/chart/price/PriceMonthlyItems.tsx
+++ b/front/components/chart/price/PriceMonthlyItems.tsx
@@ -31,7 +31,7 @@ const ListItems = ({ fallback, children }: ListItemsProps) => {
 };
 
 const PriceMonthlyItems = ({ fallback }: PriceMonthlyItemsProps) => {
-  const { selectedMonthInPrice, selectedYearInPrice } = useSelector((state: rootReducerType) => state.chart);
+  const { selectedMonthIndexInPrice, selectedYearInPrice } = useSelector((state: rootReducerType) => state.chart);
   const { itemsPerYear, error } = SWR.getItemsPerYear(selectedYearInPrice);
 
   const moveToStore = useCallback(() => {

--- a/front/components/recycle/ListItem.tsx
+++ b/front/components/recycle/ListItem.tsx
@@ -7,36 +7,39 @@ import { base64URL } from '../../config/config';
 type ListItemProps = {
   item: ItemsArray;
   func: (id: number) => () => void;
+  exceptPrice?: boolean;
 };
 
 export const SkeletonListItem = () => {
   return <SkeletonListDiv />;
 };
 
-const ListItem = ({ item, func }: ListItemProps) => {
+const ListItem = ({ item, func, exceptPrice }: ListItemProps) => {
   return (
     <ListContainer key={item.id} onClick={func(item.id)} data-testid='listItem'>
-      <ImageContainer>
-        <ThumbnailWrapper>
-          <Thumbnail>
-            <Centered>
-              <CImage
-                src={`${item.Images[0].src}`}
-                alt={item.productName}
-                width={100}
-                height={100}
-                placeholder='blur'
-                blurDataURL={`data:image/gif;base64,${base64URL}`}
-              />
-            </Centered>
-          </Thumbnail>
-        </ThumbnailWrapper>
-      </ImageContainer>
-      <NameContainer>
-        <span>{item.productName}</span>
-        <p>{item.categori}</p>
-      </NameContainer>
-      <PriceContainer>{item.price.toLocaleString('ko-KR')}</PriceContainer>
+      <Flex>
+        <ImageContainer>
+          <ThumbnailWrapper>
+            <Thumbnail>
+              <Centered>
+                <CImage
+                  src={`${item.Images[0].src}`}
+                  alt={item.productName}
+                  width={100}
+                  height={100}
+                  placeholder='blur'
+                  blurDataURL={`data:image/gif;base64,${base64URL}`}
+                />
+              </Centered>
+            </Thumbnail>
+          </ThumbnailWrapper>
+        </ImageContainer>
+        <NameContainer>
+          <span>{item.productName}</span>
+          <p>{item.categori}</p>
+        </NameContainer>
+      </Flex>
+      {exceptPrice ? null : <PriceContainer>{item.price.toLocaleString('ko-KR')}</PriceContainer>}
       <DateContainer>{`${item.purchaseDay.substring(0, 7)}`}</DateContainer>
     </ListContainer>
   );
@@ -51,7 +54,6 @@ const ListContainer = styled.div`
   width: 100%;
   height: auto;
   padding: 5px 5px;
-  /* border: 0.5px solid ${({ theme }) => theme.colors.mainGrey}; */
   border-radius: 10px;
   transition: box-shadow 0.1s ease-out;
   cursor: pointer;
@@ -59,6 +61,14 @@ const ListContainer = styled.div`
   &:hover {
     box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
   }
+`;
+
+const Flex = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  width: 100%;
+  height: auto;
 `;
 
 const SkeletonListDiv = styled.div`
@@ -83,7 +93,7 @@ const NameContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
-  width: 35%;
+  width: 60%;
   height: auto;
 
   > span {

--- a/front/hooks/useDelayCall.tsx
+++ b/front/hooks/useDelayCall.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+
+const useDelayCall = (func: any, dependency: any) => {
+  let isInvokeFunc = false;
+
+  useEffect(() => {
+    isInvokeFunc = true;
+
+    if (isInvokeFunc) {
+      func();
+      isInvokeFunc = false;
+    }
+  }, [dependency]);
+};
+
+export default useDelayCall;

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/router';
 import { ThemeProvider } from 'styled-components';
 import GlobalStyle from '../styles/GlobalStyle';
 import theme from '../styles/theme';
+import { ConfigProvider } from 'antd';
 
 import wrapper from '../store/configureStore';
 import AppLayout from '../components/AppLayout';
@@ -50,11 +51,13 @@ const MyApp = ({ Component, pageProps }: AppPropsAddLayout) => {
 
   return (
     <SWRConfig>
-      <ThemeProvider theme={theme}>
-        <GlobalStyle isPhoneMenuClick={isPhoneMenuClick} isSearchClick={isSearchClick} />
-        {isTransitionLoading && <TransitionPageLoading />}
-        {getLayout(<Component {...pageProps} />)}
-      </ThemeProvider>
+      <ConfigProvider theme={{ token: { colorPrimary: 'hsl(23, 100%, 50%)' } }}>
+        <ThemeProvider theme={theme}>
+          <GlobalStyle isPhoneMenuClick={isPhoneMenuClick} isSearchClick={isSearchClick} />
+          {isTransitionLoading && <TransitionPageLoading />}
+          {getLayout(<Component {...pageProps} />)}
+        </ThemeProvider>
+      </ConfigProvider>
     </SWRConfig>
   );
 };

--- a/front/reducers/chart.tsx
+++ b/front/reducers/chart.tsx
@@ -3,18 +3,55 @@ import produce from 'immer';
 import * as t from './type';
 
 import { ChartinitialState } from './types/chart';
+import { Categories } from '../util/Types/response';
 
 const currentYear = new Date().getFullYear();
 
 export const initialState: ChartinitialState = {
   selectedYearInPrice: currentYear,
-  selectedMonthInPrice: null,
+  selectedMonthIndexInPrice: 0,
   selectedCategoriesInPrice: [],
+};
+
+export const selectYearAction = (year: number) => {
+  return {
+    type: t.SELECT_YEAR,
+    data: year,
+  };
+};
+
+export const selectCategoriesAction = (data: Categories[]) => {
+  return {
+    type: t.SELECT_CATEGORIES,
+    data,
+  };
+};
+
+export const getChartPointId = (id: number) => {
+  return {
+    type: t.GET_CHART_ID,
+    data: id,
+  };
 };
 
 export default (state = initialState, action: AnyAction) => {
   return produce(state, draft => {
     switch (action.type) {
+      case t.SELECT_YEAR: {
+        draft.selectedYearInPrice = action.data;
+        break;
+      }
+      case t.SELECT_CATEGORIES: {
+        draft.selectedCategoriesInPrice = action.data;
+        break;
+      }
+      case t.GET_CHART_ID: {
+        draft.selectedMonthIndexInPrice = action.data;
+        break;
+      }
+      default: {
+        break;
+      }
     }
   });
 };

--- a/front/reducers/type.tsx
+++ b/front/reducers/type.tsx
@@ -53,3 +53,11 @@ export const PATCH_ITEM_FAILURE = 'PATCH_ITEM_FAILURE' as const;
 export const DELETE_ITEM_REQUEST = 'DELETE_ITEM_REQUEST' as const;
 export const DELETE_ITEM_SUCCESS = 'DELETE_ITEM_SUCCESS' as const;
 export const DELETE_ITEM_FAILURE = 'DELETE_ITEM_FAILURE' as const;
+
+// chart
+
+export const SELECT_YEAR = 'SELECT_YEAR' as const;
+
+export const SELECT_CATEGORIES = 'SELECT_CATEGORIES' as const;
+
+export const GET_CHART_ID = 'GET_CHART_ID' as const;

--- a/front/reducers/types/chart.ts
+++ b/front/reducers/types/chart.ts
@@ -1,6 +1,7 @@
 import { Categories } from '../../util/Types/response';
+
 export interface ChartinitialState {
   selectedYearInPrice: number;
-  selectedMonthInPrice: string | null;
+  selectedMonthIndexInPrice: number;
   selectedCategoriesInPrice: Categories[];
 }

--- a/front/styles/theme.tsx
+++ b/front/styles/theme.tsx
@@ -29,6 +29,9 @@ const colors = {
   success: '#68C260',
   warnning: '#F4A100',
   milk: '#f7f6ee',
+  orange: 'hsl(23, 100%, 50%)',
+  lightBlack: 'hsl(0, 0%, 27%)',
+  lightBlue: '#4096ff',
 };
 
 export type DirectionType = 'normal' | 'reverse' | 'alternate' | 'alternate-reverse';

--- a/front/util/Chart/Price/convertData.tsx
+++ b/front/util/Chart/Price/convertData.tsx
@@ -3,42 +3,48 @@ import { ItemsArray, Categories } from '../../Types/response';
 export const lineColors = ['hsl(0, 0%, 27%)', 'hsl(23, 100%, 50%)'];
 
 export const emptyChartData = { id: 'empty', color: '#454545', data: [] };
+export const emptyChartMonthlyItems: ItemsArray[][] = [];
 
 export const convertDataToDesktopChart = (swrData: ItemsArray[] | undefined, year: number, categori: Categories[]) => {
   const Data = [];
   // 전달받은 데이터 중 뽑아야 하는 데이터는,
-  const sortedTotalData = SortedTotalData(swrData, year);
-  const sortedDataByCategories = SortedDataByCategories(swrData, year, categori);
+  const { lineData: sortedTotalData } = SortedTotalData(swrData, year);
+  const { lineData: sortedDataByCategories, items: sortedCategoriesMonthlyItems } = SortedDataByCategories(
+    swrData,
+    year,
+    categori
+  );
   const doesExistData = sortedTotalData.data.every(item => item.y === 0);
   Data.push(sortedTotalData);
   categori.length > 0 && Data.push(sortedDataByCategories);
 
-  return { Data, doesExistData };
+  return { Data, doesExistData, sortedCategoriesMonthlyItems };
 };
 
 export const SortedTotalData = (swrDate: ItemsArray[] | undefined, year: number) => {
-  if (!swrDate) return emptyChartData;
-  const { monthlyPriceArray } = extractMonthlyData(swrDate, year);
+  if (!swrDate) return { lineData: emptyChartData, items: emptyChartMonthlyItems };
+  const { monthlyPriceArray, monthlyItemsArray } = extractMonthlyData(swrDate, year);
   const totalLineData = formatingChartData('TotalItems', 'hsl(0, 0%, 27%)', monthlyPriceArray);
-  return totalLineData;
+  return { lineData: totalLineData, items: monthlyItemsArray };
 };
 
 export const SortedDataByCategories = (swrDate: ItemsArray[] | undefined, year: number, categori: Categories[]) => {
-  if (!swrDate) return emptyChartData;
+  if (!swrDate) return { lineData: emptyChartData, items: emptyChartMonthlyItems };
   const sortedItemsArray = swrDate.filter(item => categori.includes(item.categori));
-  const { monthlyPriceArray } = extractMonthlyData(sortedItemsArray, year);
+  const { monthlyPriceArray, monthlyItemsArray } = extractMonthlyData(sortedItemsArray, year);
   const matchedLineDataByCategories = formatingChartData(
     createChartId(categori),
     'hsl(23, 100%, 50%)',
     monthlyPriceArray
   );
-  return matchedLineDataByCategories;
+  return { lineData: matchedLineDataByCategories, items: monthlyItemsArray };
 };
 
 export const extractMonthlyData = (swrData: ItemsArray[] | undefined, year: number) => {
   const monthlyItemsArray: ItemsArray[][] = [];
   const monthlyPriceArray: { x: string; y: number }[] = [];
   if (!swrData || swrData.length === 0) {
+    const { monthlyItemsArray, monthlyPriceArray } = createDummyData(year);
     return { monthlyItemsArray, monthlyPriceArray };
   }
   // 1월부터 12월까지 fliter 된 데이터들
@@ -46,7 +52,7 @@ export const extractMonthlyData = (swrData: ItemsArray[] | undefined, year: numb
     const Month = i < 10 ? `0${i}` : `${i}`;
     const Date = year + '-' + Month;
     const itemsArray = swrData.filter(cloth => cloth.purchaseDay.substring(0, 7) === Date);
-    const Price = summedMonthlyPrice(itemsArray);
+    const Price = summedPrice(itemsArray);
     monthlyItemsArray.push(itemsArray);
     monthlyPriceArray.push({ x: Date, y: Price });
   }
@@ -54,9 +60,19 @@ export const extractMonthlyData = (swrData: ItemsArray[] | undefined, year: numb
   return { monthlyItemsArray, monthlyPriceArray };
 };
 
-export const summedMonthlyPrice = (itemsArray: ItemsArray[] | undefined) => {
+export const summedPrice = (itemsArray: ItemsArray[] | undefined) => {
   if (!itemsArray) return 0;
   return itemsArray.reduce((sum, item) => (sum = sum + item.price), 0) / 1000;
+};
+
+export const flatMonthlyItemsArray = (array: ItemsArray[][]) => {
+  return array.flat();
+};
+
+export const summedTotalPriceWithCategories = (array: ItemsArray[][]) => {
+  const flatItemsArray = flatMonthlyItemsArray(array);
+  const summaryPrice = summedPrice(flatItemsArray);
+  return summaryPrice;
 };
 
 export const createChartId = (categori: Categories[]) => {
@@ -70,4 +86,15 @@ export const formatingChartData = (id: string, color: string, data: { x: string;
     color: color,
     data: data,
   };
+};
+
+export const createDummyData = (year: number) => {
+  const monthlyItemsArray: ItemsArray[][] = [];
+  const monthlyPriceArray = [];
+  for (let i = 1; i <= 12; i++) {
+    const Month = i < 10 ? `0${i}` : `${i}`;
+    const Date = year + '-' + Month;
+    monthlyPriceArray.push({ x: Date, y: 0 });
+  }
+  return { monthlyItemsArray, monthlyPriceArray };
 };

--- a/front/util/PrimitiveUtils/number.tsx
+++ b/front/util/PrimitiveUtils/number.tsx
@@ -1,0 +1,3 @@
+export const calcPercentage = (numerator: number, denominator: number) => {
+  return Math.ceil((numerator / denominator) * 100);
+};


### PR DESCRIPTION
## 진행 사항

- 12달 기준 Price Chart 생성
- 실 server 에서 전달받은 데이터를 기반으로 Chart 에 알맞게 데이터 수정하기 위한 함수 구현(Utils/Price)
- Redux State/dispatch 를 활용하여 클라이언트 내 상태 공유(year, categories, monthIndex)
- 각각의 상태값은 chart hover, check tag, delete tag, choose year 을 통해 dispatch 되어 state 업데이트
- 업데이트 된 state 를 인자로 받는 SWR fetch 를 통해 server data 최신화
- 나머지 컴포넌트 내 공유된 같은 key SWR 을 통해 전역 변수로 사용