### PR TITLE
refactor: PriceChart -> 모바일 환경 내 차트 데이터 계산 util 추가 & 모바일 차트 데이터 최신화

### DIFF
--- a/front/components/chart/price/PriceChartDesktop.tsx
+++ b/front/components/chart/price/PriceChartDesktop.tsx
@@ -3,22 +3,24 @@ import { ResponsiveLine } from '@nivo/line';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
 import { SWR } from '../../../util/SWR/API';
-import { convertDataToDesktopChart } from '../../../util/Chart/Price/convertData';
+import { convertDataToChart } from '../../../util/Chart/Price/convertData';
 
 import PriceCustomToolTip from './PriceCustomToolTip';
 import { rootReducerType } from '../../../reducers/types';
 
 type PriceChartDesktopProps = {
   fallback?: boolean;
+  device: 'desktop' | 'phone';
 };
 
-const PriceChartDesktop = ({ fallback }: PriceChartDesktopProps) => {
+const PriceChartDesktop = ({ fallback, device }: PriceChartDesktopProps) => {
   const { selectedYearInPrice, selectedCategoriesInPrice } = useSelector((state: rootReducerType) => state.chart);
   const { itemsPerYear, error } = SWR.getItemsPerYear(selectedYearInPrice);
-  const { Data, doesExistData } = convertDataToDesktopChart(
+  const { Data, doesExistData } = convertDataToChart(
     itemsPerYear?.items,
     selectedYearInPrice,
-    selectedCategoriesInPrice
+    selectedCategoriesInPrice,
+    device
   );
   const length = Data[1] ? Data[1].id.length : 0;
 

--- a/front/components/chart/price/PriceChartMobile.tsx
+++ b/front/components/chart/price/PriceChartMobile.tsx
@@ -2,19 +2,27 @@ import React from 'react';
 import { ResponsiveLine } from '@nivo/line';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
-import { SWR } from '../../../util/SWR/API';
-
-import { dummyPriceData } from '../__mocks__/PriceData';
 import { rootReducerType } from '../../../reducers/types';
+import { SWR } from '../../../util/SWR/API';
+import { convertDataToChart } from '../../../util/Chart/Price/convertData';
+
+import PriceCustomToolTip from './PriceCustomToolTip';
 
 type PriceChartMobileProps = {
   fallback?: boolean;
+  device: 'desktop' | 'phone';
 };
 
-const PriceChartMobile = ({ fallback }: PriceChartMobileProps) => {
-  const { selectedYearInPrice } = useSelector((state: rootReducerType) => state.chart);
+const PriceChartMobile = ({ fallback, device }: PriceChartMobileProps) => {
+  const { selectedYearInPrice, selectedCategoriesInPrice } = useSelector((state: rootReducerType) => state.chart);
   const { itemsPerYear, error } = SWR.getItemsPerYear(selectedYearInPrice);
-  console.log('PriceChartMobile', itemsPerYear);
+  const { Data, doesExistData } = convertDataToChart(
+    itemsPerYear?.items,
+    selectedYearInPrice,
+    selectedCategoriesInPrice,
+    device
+  );
+  const length = Data[1] ? Data[1].id.length : 0;
 
   if (fallback) {
     return (
@@ -26,24 +34,40 @@ const PriceChartMobile = ({ fallback }: PriceChartMobileProps) => {
     return (
       <PriceChartSection>
         <ResponsiveLine
-          data={dummyPriceData}
-          margin={{ top: 20, right: 10, bottom: 10, left: 10 }}
+          data={Data}
+          margin={{ top: 20, right: 20, bottom: 50, left: 60 }}
           xScale={{ type: 'point' }}
           yScale={{
             type: 'linear',
             min: 'auto',
-            max: 'auto',
-            stacked: true,
+            max: doesExistData ? 1000 : 'auto',
+            stacked: false,
             reverse: false,
           }}
           yFormat=' >-.2f'
-          curve='cardinal'
+          curve='step'
           axisTop={null}
           axisRight={null}
-          axisBottom={null}
-          axisLeft={null}
+          axisBottom={{
+            tickSize: 0,
+            tickPadding: 13,
+            tickRotation: 0,
+            legend: 'year',
+            legendOffset: 40,
+            legendPosition: 'middle',
+          }}
+          axisLeft={{
+            tickSize: 0,
+            tickPadding: 5,
+            tickRotation: 0,
+            legend: 'price(만 원)',
+            legendOffset: -40,
+            legendPosition: 'middle',
+          }}
           enableGridX={false}
-          colors={{ scheme: 'dark2' }}
+          colors={({ color }) => {
+            return color;
+          }}
           lineWidth={1}
           pointSize={4}
           pointColor={{ theme: 'labels.text.fill' }}
@@ -56,8 +80,35 @@ const PriceChartMobile = ({ fallback }: PriceChartMobileProps) => {
           areaOpacity={0.15}
           crosshairType='x'
           useMesh={true}
+          legends={[
+            {
+              anchor: 'bottom',
+              direction: 'row',
+              justify: false,
+              translateX: 0,
+              translateY: -10,
+              itemsSpacing: length,
+              itemDirection: 'bottom-to-top',
+              itemWidth: 80,
+              itemHeight: 20,
+              itemOpacity: 0.75,
+              symbolSize: 12,
+              symbolShape: 'circle',
+              symbolBorderColor: 'rgba(0, 0, 0, .5)',
+              effects: [
+                {
+                  on: 'hover',
+                  style: {
+                    itemBackground: 'rgba(0, 0, 0, .03)',
+                    itemOpacity: 1,
+                  },
+                },
+              ],
+            },
+          ]}
           animate={false}
           motionConfig='wobbly'
+          sliceTooltip={PriceCustomToolTip}
         />
       </PriceChartSection>
     );

--- a/front/components/chart/price/PriceMonthlyItems.tsx
+++ b/front/components/chart/price/PriceMonthlyItems.tsx
@@ -9,11 +9,12 @@ import ListItem, { SkeletonListItem } from '../../recycle/ListItem';
 import PriceEmptyMonthlyItmes from './PriceEmptyMonthlyItems';
 import { SWR } from '../../../util/SWR/API';
 import { ItemsArray } from '../../store/TableData';
-import { SortedTotalData } from '../../../util/Chart/Price/convertData';
+import { SortExtractedData } from '../../../util/Chart/Price/convertData';
 import { rootReducerType } from '../../../reducers/types';
 
 type PriceMonthlyItemsProps = {
   fallback?: boolean;
+  device: 'desktop' | 'phone';
 };
 type ListItemsProps = Pick<PriceMonthlyItemsProps, 'fallback'> & { children: React.ReactNode };
 
@@ -32,13 +33,14 @@ const ListItems = ({ fallback, children }: ListItemsProps) => {
   }
 };
 
-const PriceMonthlyItems = ({ fallback }: PriceMonthlyItemsProps) => {
+const PriceMonthlyItems = ({ fallback, device }: PriceMonthlyItemsProps) => {
   const { selectedMonthIndexInPrice, selectedYearInPrice } = useSelector((state: rootReducerType) => state.chart);
   const { itemsPerYear, error } = SWR.getItemsPerYear(selectedYearInPrice);
-  const { items } = SortedTotalData(itemsPerYear?.items, selectedYearInPrice);
+  const { items } = SortExtractedData[device].Total(itemsPerYear?.items, selectedYearInPrice);
 
   const ListsPerMonth = items.length === 0 ? [] : items[selectedMonthIndexInPrice];
-  const Length = ListsPerMonth.length;
+  const Length = ListsPerMonth?.length;
+  let Month = device === 'phone' ? (selectedMonthIndexInPrice + 1) * 2 : selectedMonthIndexInPrice + 1;
 
   const moveToStore = useCallback(() => {
     Router.push('/closet/store');
@@ -56,8 +58,7 @@ const PriceMonthlyItems = ({ fallback }: PriceMonthlyItemsProps) => {
       <ResultsListContainer>
         <Flex>
           <h4>
-            <Strong>{selectedMonthIndexInPrice + 1}</Strong> 월 저장 의류:{' '}
-            <Strong>{fallback ? '--' : ListsPerMonth?.length}</Strong> 벌{' '}
+            <Strong>{Month}</Strong> 월 저장 의류: <Strong>{fallback ? '--' : ListsPerMonth?.length}</Strong> 벌{' '}
           </h4>
         </Flex>
         {Length == 0 && <PriceEmptyMonthlyItmes />}

--- a/front/components/chart/price/PriceSummuryInCategori.tsx
+++ b/front/components/chart/price/PriceSummuryInCategori.tsx
@@ -8,12 +8,13 @@ import { Progress, Tag } from 'antd';
 import LinkCardLayout from '../../recycle/layout/LinkCardLayout';
 import { rootReducerType } from '../../../reducers/types';
 import { selectCategoriesAction } from '../../../reducers/chart';
-import { SortedDataByCategories, summedTotalPriceWithCategories } from '../../../util/Chart/Price/convertData';
+import { SortExtractedData, summedTotalPriceWithCategories } from '../../../util/Chart/Price/convertData';
 import { calcPercentage } from '../../../util/PrimitiveUtils/number';
 import { convertNumberToKRWCurrency } from '../../../util/PrimitiveUtils/string';
 
 type PriceSummuryInCategoriProps = {
   fallback?: boolean;
+  device: 'desktop' | 'phone';
 };
 
 const SkeletonPriceSummury = () => {
@@ -34,11 +35,15 @@ const SkeletonPriceSummury = () => {
 
 const conicColors = { '0%': 'hsl(0, 0%, 27%)', '50%': 'hsl(23, 100%, 50%)', '100%': '#ffe58f' };
 
-const PriceSummuryInCategori = ({ fallback }: PriceSummuryInCategoriProps) => {
+const PriceSummuryInCategori = ({ fallback, device }: PriceSummuryInCategoriProps) => {
   const dispatch = useDispatch();
   const { selectedCategoriesInPrice, selectedYearInPrice } = useSelector((state: rootReducerType) => state.chart);
   const { itemsPerYear, error } = SWR.getItemsPerYear(selectedYearInPrice);
-  const { items } = SortedDataByCategories(itemsPerYear?.items, selectedYearInPrice, selectedCategoriesInPrice);
+  const { items } = SortExtractedData[device].FilteredCategory(
+    itemsPerYear?.items,
+    selectedYearInPrice,
+    selectedCategoriesInPrice
+  );
 
   // items 를 flat 하여 summury 와 percentage 를 계산
   const summaryPrice = summedTotalPriceWithCategories(items) * 1000;

--- a/front/pages/closet/reports/price/index.tsx
+++ b/front/pages/closet/reports/price/index.tsx
@@ -53,15 +53,15 @@ const Price = ({ device }: PriceProps) => {
           {windowWidth == 'phone' && <SelectYearPicker />}
         </TitleSection>
         {windowWidth === 'desktop' ? (
-          <PriceChartAtDesktop fallback={isLoading} />
+          <PriceChartAtDesktop fallback={isLoading} device={windowWidth} />
         ) : (
-          <PriceChartAtPhone fallback={isLoading} />
+          <PriceChartAtPhone fallback={isLoading} device={windowWidth} />
         )}
         <SelectCategories />
         <Intersection marginBottom={1.5} />
         <CardSection>
-          <PriceSummuryInCategori fallback={isLoading} />
-          <PriceMonthlyItems fallback={isLoading} />
+          <PriceSummuryInCategori fallback={isLoading} device={windowWidth} />
+          <PriceMonthlyItems fallback={isLoading} device={windowWidth} />
         </CardSection>
       </PageMainLayout>
     </PageLayout>


### PR DESCRIPTION
## 진행 사항

- 데스크탑 환경과 달리 모바일 환경은 디바이스의 폭이 좁기 때문에, 12월 간격의 차트를 그리기에는 무리가 있다
- 이에 모바일 환경에서는 6개월 기준으로 데이터를 보여주는것이 좋다 판단
- price 페이지로부터 device 정보를 받아, 함수에 적용시켜 이에 맞게 12월, 6월 기준으로 데이터 생성