### PR TITLE
Feat/components: Overview 내 image component 수정 및 빈 데이터시 렌더링 부분 삭제

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -3,6 +3,8 @@ name: CD
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "front/**"
 
   # Allows you to run this workflow manually from the Actions tab
   #Now we have got the access of EC2 and we will start the deploy .

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -27,7 +27,6 @@ jobs:
             sudo chown -R $USER:$USER .
             cd Closet/back
             sudo npx pm2 kill
-            sudo git gc --aggressive --prune=now 
             sudo git stash && sudo git pull origin main && sudo git stash pop
             sudo npm install -g npm@latest
             sudo npm start

--- a/front/components/main/CurrentYearPrice.tsx
+++ b/front/components/main/CurrentYearPrice.tsx
@@ -1,10 +1,9 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import Router from 'next/router';
 
 import LinkCardLayout from '../recycle/layout/LinkCardLayout';
 import TotalPriceBar from './chart/TotalPriceBar';
-import EmptyData from '../recycle/EmptyData';
 
 type CurrentPriceProps = {
   totalPrice: number;
@@ -17,14 +16,6 @@ const CurrentYearPrice = ({ totalPrice, currentPrice }: CurrentPriceProps) => {
   const moveToStore = useCallback(() => {
     Router.push('/closet/store');
   }, []);
-
-  if (!totalPrice || !currentPrice) {
-    return (
-      <LinkCardLayout Subject='TotalPrice' Address='Store' onMove={moveToStore} divided={2}>
-        <EmptyData height={40} />
-      </LinkCardLayout>
-    );
-  }
 
   return (
     <LinkCardLayout Subject='TotalPrice' Address='Store' onMove={moveToStore} divided={2}>

--- a/front/components/main/LastItem.tsx
+++ b/front/components/main/LastItem.tsx
@@ -1,14 +1,12 @@
 import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import Router from 'next/router';
-import Image from 'next/image';
 
 import LinkCardLayout from '../recycle/layout/LinkCardLayout';
+import CenteredPositionImage from '../recycle/CenteredPositionImage';
 import { ItemsArray } from '../store/TableData';
-import { base64URL } from '../../config/config';
 
 import { media } from '../../styles/media';
-import EmptyData from '../recycle/EmptyData';
 
 type LastItemProps = {
   item: ItemsArray;
@@ -19,33 +17,17 @@ const LastItem = ({ item }: LastItemProps) => {
     Router.push(`/closet/details/${item.id}`);
   }, []);
 
-  if (!item) {
-    return (
-      <LinkCardLayout Subject='Last Item' Address='Detail' onMove={moveToDetail} divided={2}>
-        <EmptyData height={40} />
-      </LinkCardLayout>
-    );
-  }
-
   return (
     <LinkCardLayout Subject='Last Item' Address='Detail' onMove={moveToDetail} divided={2}>
       <LastItemSection>
-        <ImageDiv>
-          <ThumbnailWrapper>
-            <Thumbnail>
-              <Centered>
-                <CImage
-                  src={`${item.Images[0].src}`}
-                  alt={item.productName}
-                  width={100}
-                  height={100}
-                  placeholder='blur'
-                  blurDataURL={`data:image/gif;base64,${base64URL}`}
-                />
-              </Centered>
-            </Thumbnail>
-          </ThumbnailWrapper>
-        </ImageDiv>
+        <CenteredPositionImage
+          shape='radius'
+          radius={20}
+          width={95}
+          height={95}
+          src={item.Images[0].src}
+          alt={item.productName}
+        />
         <DetailDiv>
           <ItemName>{`${item.productName}`}</ItemName>
           <Purchase>{`구매 날짜 : ${item.purchaseDay.substring(0, 7)}`}</Purchase>
@@ -64,11 +46,6 @@ const LastItemSection = styled.section`
   align-items: center;
   width: 100%;
   height: auto;
-`;
-
-const ImageDiv = styled.div`
-  width: 95px;
-  height: 95px;
 `;
 
 const DetailDiv = styled.div`
@@ -100,37 +77,3 @@ const Purchase = styled.p`
 `;
 
 const Price = styled(Purchase)``;
-
-const ThumbnailWrapper = styled.div`
-  width: 100%;
-`;
-
-const Thumbnail = styled.div`
-  position: relative;
-  padding-top: 100%;
-  overflow: hidden;
-  border-radius: 20px;
-`;
-
-const Centered = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  -webkit-transform: translate(50%, 50%);
-  -ms-transform: translate(50%, 50%);
-  transform: translate(50%, 50%);
-`;
-
-const CImage = styled(Image)`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  -webkit-transform: translate(-50%, -50%);
-  -ms-transform: translate(-50%, -50%);
-  transform: translate(-50%, -50%);
-`;

--- a/front/components/main/RecentlyItem.tsx
+++ b/front/components/main/RecentlyItem.tsx
@@ -5,7 +5,6 @@ import Router from 'next/router';
 import LinkCardLayout from '../recycle/layout/LinkCardLayout';
 import { ItemsArray } from '../store/TableData';
 import ListItem from '../recycle/ListItem';
-import EmptyData from '../recycle/EmptyData';
 
 type RecentlyProps = {
   items: ItemsArray[];
@@ -21,14 +20,6 @@ const RecentlyItem = ({ items }: RecentlyProps) => {
     },
     []
   );
-
-  if (items.length === 0) {
-    return (
-      <LinkCardLayout Subject='Recently Eroll' Address='Store' onMove={moveToStore} divided={1}>
-        <EmptyData height={80} />
-      </LinkCardLayout>
-    );
-  }
 
   return (
     <LinkCardLayout Subject='Recently Eroll' Address='Store' onMove={moveToStore} divided={1}>

--- a/front/components/main/TotalData.tsx
+++ b/front/components/main/TotalData.tsx
@@ -7,7 +7,6 @@ import LinkCardLayout from '../recycle/layout/LinkCardLayout';
 import { categoriObject } from '../store/TableData';
 
 import Router from 'next/router';
-import EmptyData from '../recycle/EmptyData';
 
 type Props = {
   data: categoriObject | {};
@@ -18,14 +17,6 @@ const TotalData = ({ data, total }: Props) => {
   const moveToStore = useCallback(() => {
     Router.push('/closet/store');
   }, []);
-
-  if (Object.keys(data).length === 0) {
-    return (
-      <LinkCardLayout Subject='total quantity' Address='Store' onMove={moveToStore} divided={1}>
-        <EmptyData height={80} />
-      </LinkCardLayout>
-    );
-  }
 
   return (
     <LinkCardLayout Subject='total quantity' Address='Store' onMove={moveToStore} divided={1}>

--- a/front/components/recycle/CenteredPositionImage.tsx
+++ b/front/components/recycle/CenteredPositionImage.tsx
@@ -5,17 +5,18 @@ import { backUrl, base64URL } from '../../config/config';
 
 type CenteredPositionImageProps = {
   shape: 'radius' | 'none';
+  radius?: number;
   width: number;
   height: number;
   src: string;
   alt: string;
 };
 
-const CenteredPositionImage = ({ shape, width, height, src, alt }: CenteredPositionImageProps) => {
+const CenteredPositionImage = ({ shape, width, height, src, alt, radius }: CenteredPositionImageProps) => {
   return (
     <ImageContainer width={width} height={height}>
       <ThumbnailWrapper>
-        <Thumbnail width={width} shape={shape}>
+        <Thumbnail width={radius ? radius * 2 : width} shape={shape}>
           <Centered>
             <CImage
               src={`${src}`}


### PR DESCRIPTION
- overview page 렌더링 시 빈 데이터가 전송되면 자동으로 전체 empty 컴포넌트가 렌더링된다
- 그렇기에 각 카드 단위의 컴포넌트 마다 빈 데이터 렌더링 조건을 삭제해도 무관하였기에 삭제
- 또한 이미지 컴포넌트 역시 이전에 구현하였던 CenteredPositionImage 로 대체
- back 폴더 내 변화가 아니라면 action 작동 안하도록 paths-ignore 설정