### PR TITLE
fix: reducer -> user -> userProfileImage 가 null 일 때 src 참조 오류 발생

### DIFF
--- a/front/reducers/user.tsx
+++ b/front/reducers/user.tsx
@@ -104,6 +104,7 @@ export default (state = initialState, action: AnyAction) => {
         draft.loadToMyInfoDone = true;
         draft.loadToMyInfoError = null;
         draft.me = action.data;
+        draft.userProfileImages = draft.me !== null ? draft.me.src : '';
         break;
       }
       case t.LOAD_TO_MY_INFO_FAILURE: {


### PR DESCRIPTION
- 첫 로그인이 되지 않았을 경우 user state 내 me 는 null 이 된다.
- 이 때 null.src 참조 오류가 발생
- 이에 조건식으로 수정