### PR TITLE
Feat/components: useUnmount 커스텀 훅 구현

### DIFF
--- a/front/components/recycle/layout/PageLayout.tsx
+++ b/front/components/recycle/layout/PageLayout.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import React from 'react';
 import styled from 'styled-components';
-import * as t from '../../../reducers/type';
+import useUnmountMenu from '../../../hooks/useUnmountMenu';
 
 import Nav from '../../Nav';
 import Intersection from '../Intersection';
@@ -14,11 +13,7 @@ type Props = {
 };
 
 const PageLayout = ({ children }: Props): JSX.Element => {
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    dispatch({ type: t.UNMOUNT_BACKGROUND });
-  }, []);
+  useUnmountMenu();
 
   return (
     <Container>

--- a/front/components/state/developing/RenderDevelopingPage.tsx
+++ b/front/components/state/developing/RenderDevelopingPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import useLottieAnimation from '../../../hooks/useLottieAnimation';
+import useUnmountMenu from '../../../hooks/useUnmountMenu';
 
 import { media } from '../../../styles/media';
 import AButton from '../../recycle/buttonElements/AButton';
@@ -10,6 +11,7 @@ import { NavRow } from '../../main/state/RenderPageInLoading';
 import { useLottiePropsByDeveloping, PropsByEmpty } from './data/Data';
 
 const RenderDevelopingPage = ({ state }: PropsByEmpty) => {
+  useUnmountMenu();
   const View = useLottieAnimation(useLottiePropsByDeveloping[state].options);
 
   return (

--- a/front/components/state/empty/RenderEmptyPage.tsx
+++ b/front/components/state/empty/RenderEmptyPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import useLottieAnimation from '../../../hooks/useLottieAnimation';
+import useUnmountMenu from '../../../hooks/useUnmountMenu';
 
 import { media } from '../../../styles/media';
 import AButton from '../../recycle/buttonElements/AButton';
@@ -10,6 +11,7 @@ import { NavRow } from '../../main/state/RenderPageInLoading';
 import { useLottiePropsByEmpty, PropsByEmpty } from './data/Data';
 
 const RenderEmptyPage = ({ state }: PropsByEmpty) => {
+  useUnmountMenu();
   const View = useLottieAnimation(useLottiePropsByEmpty[state].options);
 
   return (

--- a/front/components/state/error/RenderErrorPage.tsx
+++ b/front/components/state/error/RenderErrorPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import useLottieAnimation from '../../../hooks/useLottieAnimation';
+import useUnmountMenu from '../../../hooks/useUnmountMenu';
 
 import { media } from '../../../styles/media';
 import AButton from '../../recycle/buttonElements/AButton';
@@ -10,6 +11,7 @@ import { NavRow } from '../../main/state/RenderPageInLoading';
 import { useLottiePropsByError, PropsByError } from './data/Data';
 
 const RenderErrorPage = ({ state }: PropsByError) => {
+  useUnmountMenu();
   const View = useLottieAnimation(useLottiePropsByError[state].options);
 
   return (

--- a/front/components/state/error/RenderNextErrorPage.tsx
+++ b/front/components/state/error/RenderNextErrorPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import useLottieAnimation from '../../../hooks/useLottieAnimation';
+import useUnmountMenu from '../../../hooks/useUnmountMenu';
 import { useLottiePropsByNextError, PropsByNextError } from './data/Data';
 
 import { Container, IconContainer, NotifiedSentence } from './RenderErrorPage';
@@ -10,6 +11,7 @@ type RenderNextErrorProps = PropsByNextError & {
 };
 
 const RenderNextErrorPage = ({ state, statusCode }: RenderNextErrorProps) => {
+  useUnmountMenu();
   const View = useLottieAnimation(useLottiePropsByNextError[state].options);
 
   return (

--- a/front/hooks/useUnmountMenu.tsx
+++ b/front/hooks/useUnmountMenu.tsx
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import * as t from '../reducers/type';
+
+const useUnmountMenu = () => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch({ type: t.UNMOUNT_BACKGROUND });
+  }, []);
+};
+
+export default useUnmountMenu;


### PR DESCRIPTION
- color, sort 페이지로 menu link 를 통해 이동 시 페이지가 렌더되었음에도 사이드 메뉴가 unmount 되지 않았음
- 이에 매 페이지 렌더시 useEffect 를 통해 screenEvent action 을 통해 이를 해결하고자 함
- 다른 페이지에서 이미 구현된 로직을 재사용하기 위해 커스텀훅 구현