### PR TITLE
fix: item preference 점수가 rate 에 제대로 반영되지 않는 버그 수정

### DIFF
--- a/front/components/details/DetailsMain.tsx
+++ b/front/components/details/DetailsMain.tsx
@@ -20,7 +20,7 @@ const DetailsMain = () => {
         <Categori>{singleItem && singleItem.categori}</Categori>
         <ProductName>{singleItem && singleItem.productName}</ProductName>
         <RateBox>
-          <CRate disabled defaultValue={singleItem ? singleItem.preference : 1} />
+          <CRate disabled value={singleItem ? singleItem.preference : 1} />
           <span>{singleItem ? singleItem.preference : 1}</span>
         </RateBox>
         <Descriptions>{singleItem && singleItem.description}</Descriptions>

--- a/front/components/details/DetailsTapContainer.tsx
+++ b/front/components/details/DetailsTapContainer.tsx
@@ -44,7 +44,7 @@ const DetailsTapContainer = () => {
                   {measureValue &&
                     measureValue.map(v => {
                       return (
-                        <TapChildren name={capitalizeFirstWord(v[0])} unit='cm'>
+                        <TapChildren name={capitalizeFirstWord(v[0])} unit={v[0] == 'size' ? 'mm' : 'cm'}>
                           <span>{v[1]}</span>
                         </TapChildren>
                       );


### PR DESCRIPTION
- Store 페이지나 기타 다른 경로에서 한 아이템의 상세페이지로 이동 시, 첫 렌더링에서 Rate 컴포넌트가 제대로 렌더되지 않는 버그 발생
- 사실 버그라기 보단 defaulValue 와 wrapper 로 생성되는 Store 간의 상호작용 과정에서 생긴 문제
- defaultValue -> value 로 변경해줌으로서 fix